### PR TITLE
add support for npm/bower so folks can use the attack data programatically

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,9 @@
+{
+  "name": "h5sc",
+  "version": "0.0.0",
+  "main": [
+    "items.js",
+  "payloads.js",
+  "categories.js"
+    ]
+}

--- a/categories.js
+++ b/categories.js
@@ -1,6 +1,19 @@
 /* Categories - the available categories */
-var categories =
-{
+(function (root, factory) {
+    if (typeof define === 'function' && define.amd) {
+        // AMD. Register as an anonymous module.
+        define([], factory);
+    } else if (typeof exports === 'object') {
+        // Node. Does not work with strict CommonJS, but
+        // only CommonJS-like environments that support module.exports,
+        // like Node.
+        module.exports = factory();
+    } else {
+        // Browser globals (root is window)
+        root.categories = factory();
+  }
+}(this, function () {
+return {
     'html5'         : {
         'en' : 'Vectors making use of HTML5 features',
         'ja' : 'HTML5\u306e\u6a5f\u80fd\u3092\u4f7f\u3063\u305f\u624b\u6cd5',
@@ -119,3 +132,4 @@ var categories =
 		'zh' : 'Clickjacking和UI Redressing的向量'
     }
 }
+}));

--- a/items.js
+++ b/items.js
@@ -1,6 +1,20 @@
 /* Items - the set of available items and vectors */
-var items = 
-[
+
+(function (root, factory) {
+  if (typeof define === 'function' && define.amd) {
+    // AMD. Register as an anonymous module.
+    define([], factory);
+  } else if (typeof exports === 'object') {
+    // Node. Does not work with strict CommonJS, but
+    // only CommonJS-like environments that support module.exports,
+    // like Node.
+    module.exports = factory();
+  } else {
+    // Browser globals (root is window)
+    root.items = factory();
+  }
+}(this, function () {
+return [
     { /* ID 1 - XSS via formaction - requiring user interaction (1) */
         'id'         : 1, 
         'category'   : 'html5', 
@@ -4858,3 +4872,4 @@ var items =
         'reporter'  : '.mario'
     }    
 ]
+}));

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,0 +1,11 @@
+var items = require('../items'),
+    payloads = require('../payload'),
+    categories = require('../categories');
+
+var h5sc = {};
+
+h5sc.items = items;
+h5sc.payloads = payloads;
+h5sc.categories = categories;
+
+module.exports = h5sc;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "H5SC",
+  "version": "0.0.0",
+  "description": "HTML5 Security Cheatsheet",
+  "main": "lib/index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:cure53/H5SC.git"
+  },
+  "keywords": [
+    "security"
+  ],
+  "author": "cure53",
+  "license": "Mozilla Public License, version 2.0",
+  "bugs": {
+    "url": "https://github.com/cure53/H5SC/issues"
+  },
+  "homepage": "https://github.com/cure53/H5SC"
+}

--- a/payloads.js
+++ b/payloads.js
@@ -1,6 +1,19 @@
 /* Payload - the generic payload templates */
-var payloads = 
-{
+(function (root, factory) {
+    if (typeof define === 'function' && define.amd) {
+        // AMD. Register as an anonymous module.
+        define([], factory);
+    } else if (typeof exports === 'object') {
+        // Node. Does not work with strict CommonJS, but
+        // only CommonJS-like environments that support module.exports,
+        // like Node.
+        module.exports = factory();
+    } else {
+        // Browser globals (root is window)
+        root.payloads = factory();
+  }
+}(this, function () {
+return {
     'js_uri_alert'      : 'javascript:alert(1)',
     'js_uri_alert_2'    : 'javascript:alert(2)',
     'js_uri_alert_3'    : 'javascript:alert(3)',
@@ -34,3 +47,4 @@ var payloads =
     'jar_path'          : 'test.jar',
     'event_path'        : 'event.php'
 }
+}));


### PR DESCRIPTION
This may be beyond the scope of this repo but this pull request allows developers to use your data programatically.

Expose items, payloads and categories to a node environment so attacks data can be used programmatically via node/AMD or the browser. 
