### PR TITLE
Fix path name to payloads.js file

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,5 +1,5 @@
 var items = require('../items'),
-    payloads = require('../payload'),
+    payloads = require('../payloads'),
     categories = require('../categories');
 
 var h5sc = {};


### PR DESCRIPTION
If the package is used via npm it currently fails with the error `Cannot find module '../payload'`.  
This pull request should fix the issue.